### PR TITLE
Improved Travis-CI build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ install:
   - gem install cocoapods --pre
 before_script:
   - rm -rf ~/Library/Developer/Xcode/DerivedData
-  - pod setup
 script:
-  - pod install
+  - pod update
   - pod lib lint
   - carthage update
   - xcodebuild -workspace BMSPush.xcworkspace -scheme 'BMSPush' clean build CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO


### PR DESCRIPTION
The `pod setup` command was taking too long and caused build failures.

Example: https://travis-ci.org/ibm-bluemix-mobile-services/bms-clientsdk-swift-push/builds/175674134